### PR TITLE
enable multiarch, amd64 and arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Step 1: Check out the repository
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Step 2: Log in to Docker Hub
       - name: Log in to Docker Hub
@@ -21,12 +21,44 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Step 3: Build the Docker image
-      - name: Build Docker Image
-        run: |
-          docker build -t dumbwareio/dumbdrop:latest .
+      # Step 3: Setup QEMU to enable multiarch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      # Step 4: Push the Docker image to Docker Hub
-      - name: Push Docker Image
-        run: |
-          docker push dumbwareio/dumbdrop:latest 
+      # Step 4: Set up docker buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Step 5: Extract metadata and set versions
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # image name is dumbdrop, in the docker user's repo
+          # this allows the push to work in forks
+          images: |
+            name=${{ secrets.DOCKER_USERNAME }}/dumbdrop
+          tags: |
+            # the semantic versioning tags add "latest" when a version tag is present
+            # but since version tags aren't being used (yet?) let's add "latest" anyway
+            type=raw,value=latest
+            # output x.y.z, based on a tag vx.y.z (e.g. 1.1.2 for a tag v1.1.2)
+            type=semver,pattern={{version}}
+            # output x.y, based on a tag vx.y.z
+            type=semver,pattern={{major}}.{{minor}}
+            # output x, based on a tag vx.y.z, disabled if x is zero
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # full length sha
+            type=sha,format=long
+
+      # Step 6: build and push the image for multiple archs
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # build and push for amd64 and arm64 platforms
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
this change uses qemu, metadata-action, and build-push-action to label images and build for multiple architectures.  amd64 and arm64 are included in this change, others can be added to line 64.

this also applies semantic versions based on tags, should semantic versions tags ever be used.

inspired by https://docs.docker.com/build/ci/github-actions/multi-platform/
