### PR TITLE
Add customizable site title feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,13 @@
 # Server Configuration
 PORT=3000                  # The port the server will listen on
+DUMBDROP_TITLE=DumbDrop   # Site title displayed in header (default: DumbDrop)
 
 # Upload Limits
 MAX_FILE_SIZE=1024        # Maximum file size in MB (default: 1024 MB / 1 GB)
 
 # Security
-DUMBDROP_PIN=             # Optional 4-digit PIN protection (leave empty to disable)
+DUMBDROP_PIN=             # Optional PIN protection (4-10 digits, leave empty to disable)
 
 # Notifications
 APPRISE_URL=              # Apprise URL for notifications (leave empty to disable)
-APPRISE_MESSAGE=          # Custom message for notifications (default: "File uploaded: {filename}") 
+APPRISE_MESSAGE=          # Custom message for notifications (default: "File uploaded: {filename}")

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ No auth (unless you want it now!), no storage, no nothing. Just a simple file up
 | PORT         | Server port                           | 3000    | No       |
 | MAX_FILE_SIZE| Maximum file size in MB               | 1024    | No       |
 | DUMBDROP_PIN | PIN protection (4-10 digits)          | None    | No       |
+| DUMBDROP_TITLE| Site title displayed in header       | DumbDrop| No       |
 | APPRISE_URL  | Apprise URL for notifications         | None    | No       |
-| APPRISE_MESSAGE| Notification message template         | "File uploaded: {filename}" | No |
+| APPRISE_MESSAGE| Notification message template       | "File uploaded: {filename}" | No |
 
 ## Security Features
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DumbDrop - Simple File Upload</title>
+    <title>{{SITE_TITLE}} - Simple File Upload</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
@@ -26,7 +26,7 @@
                 <line class="sun" x1="18.36" y1="5.64" x2="19.78" y2="4.22" style="display:none"/>
             </svg>
         </button>
-        <h1>DumbDrop</h1>
+        <h1>{{SITE_TITLE}}</h1>
         <div class="upload-container" id="dropZone">
             <div class="upload-content">
                 <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/public/login.html
+++ b/public/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DumbDrop - Login</title>
+    <title>{{SITE_TITLE}} - Login</title>
     <link rel="stylesheet" href="styles.css">
     <style>
         .login-container {
@@ -57,7 +57,7 @@
 <body>
     <div class="login-container">
         <div class="pin-header">
-            <h1>DumbDrop</h1>
+            <h1>{{SITE_TITLE}}</h1>
             <h2>Enter PIN</h2>
         </div>
         <form id="pin-form">


### PR DESCRIPTION
# Add Customizable Site Title Feature

This PR adds the ability to customize the site title through an environment variable, allowing to change the dumb name to something even dumber if a dummy feels like it. 

## Changes
- Added `DUMBDROP_TITLE` environment variable to customize the site's displayed title
- Updated both main page and login page to use the custom title
- Added title customization to browser tab title as well
- Improved middleware ordering to ensure proper template variable replacement
- Added startup logging to show when a custom title is being used
- Updated documentation in README.md and .env.example

## Implementation Details
- Default title remains "DumbDrop" if no environment variable is set
- Title is replaced globally in both HTML files using the `{{SITE_TITLE}}` template variable
- Moved dynamic route handlers before static file serving to ensure proper template processing
- Added logging on startup to confirm when a custom title is being used

## Testing
Tested with:
- Default title (no environment variable)
- Custom title via environment variable
- Special characters in title
- Both main page and login page
- Browser tab title
- Docker deployment

## Documentation
Updated the following documentation:
- Added `DUMBDROP_TITLE` to environment variables table in README.md
- Updated .env.example with the new variable and description