### PR TITLE
Size and Total Storage templates for Notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ DUMBDROP_PIN=             # Optional PIN protection (4-10 digits, leave empty to
 
 # Notifications
 APPRISE_URL=              # Apprise URL for notifications (leave empty to disable)
-APPRISE_MESSAGE=          # Custom message for notifications (default: "New file uploaded: {filename} ({size})")
+APPRISE_MESSAGE=          # Custom message for notifications (default: "New file uploaded: {filename} ({size}), Storage used: {storage}")
 APPRISE_SIZE_UNIT=        # Size unit for notifications (B, KB, MB, GB, TB). Leave empty for auto

--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,5 @@ DUMBDROP_PIN=             # Optional PIN protection (4-10 digits, leave empty to
 
 # Notifications
 APPRISE_URL=              # Apprise URL for notifications (leave empty to disable)
-APPRISE_MESSAGE=          # Custom message for notifications (default: "File uploaded: {filename}")
+APPRISE_MESSAGE=          # Custom message for notifications (default: "New file uploaded: {filename} ({size})")
+APPRISE_SIZE_UNIT=        # Size unit for notifications (B, KB, MB, GB, TB). Leave empty for auto

--- a/README.md
+++ b/README.md
@@ -30,22 +30,25 @@ No auth (unless you want it now!), no storage, no nothing. Just a simple file up
 | DUMBDROP_PIN     | PIN protection (4-10 digits)          | None    | No       |
 | DUMBDROP_TITLE   | Site title displayed in header        | DumbDrop| No       |
 | APPRISE_URL      | Apprise URL for notifications         | None    | No       |
-| APPRISE_MESSAGE  | Notification message template         | "New file uploaded: {filename} ({size})" | No |
+| APPRISE_MESSAGE  | Notification message template         | New file uploaded {filename} ({size}), Storage used {storage} | No |
 | APPRISE_SIZE_UNIT| Size unit for notifications           | Auto    | No       |
 
 ## Notification Templates
 The notification message supports the following placeholders:
 - `{filename}`: Name of the uploaded file
 - `{size}`: Size of the file (formatted according to APPRISE_SIZE_UNIT)
+- `{storage}`: Total size of all files in upload directory
 
 Example message template:
 ```env
-APPRISE_MESSAGE="New file uploaded: {filename} ({size})"
+APPRISE_MESSAGE: New file uploaded {filename} ({size}), Storage used {storage}
 ```
 
 Size formatting examples:
 - Auto (default): Chooses nearest unit (e.g., "1.44MB", "256KB")
 - Fixed unit: Set APPRISE_SIZE_UNIT to B, KB, MB, GB, or TB
+
+Both {size} and {storage} use the same formatting rules based on APPRISE_SIZE_UNIT.
 
 ## Security Features
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,29 @@ No auth (unless you want it now!), no storage, no nothing. Just a simple file up
 
 ## Environment Variables
 
-| Variable      | Description                           | Default | Required |
-|--------------|---------------------------------------|---------|----------|
-| PORT         | Server port                           | 3000    | No       |
-| MAX_FILE_SIZE| Maximum file size in MB               | 1024    | No       |
-| DUMBDROP_PIN | PIN protection (4-10 digits)          | None    | No       |
-| DUMBDROP_TITLE| Site title displayed in header       | DumbDrop| No       |
-| APPRISE_URL  | Apprise URL for notifications         | None    | No       |
-| APPRISE_MESSAGE| Notification message template       | "File uploaded: {filename}" | No |
+| Variable          | Description                           | Default | Required |
+|------------------|---------------------------------------|---------|----------|
+| PORT             | Server port                           | 3000    | No       |
+| MAX_FILE_SIZE    | Maximum file size in MB               | 1024    | No       |
+| DUMBDROP_PIN     | PIN protection (4-10 digits)          | None    | No       |
+| DUMBDROP_TITLE   | Site title displayed in header        | DumbDrop| No       |
+| APPRISE_URL      | Apprise URL for notifications         | None    | No       |
+| APPRISE_MESSAGE  | Notification message template         | "New file uploaded: {filename} ({size})" | No |
+| APPRISE_SIZE_UNIT| Size unit for notifications           | Auto    | No       |
+
+## Notification Templates
+The notification message supports the following placeholders:
+- `{filename}`: Name of the uploaded file
+- `{size}`: Size of the file (formatted according to APPRISE_SIZE_UNIT)
+
+Example message template:
+```env
+APPRISE_MESSAGE="New file uploaded: {filename} ({size})"
+```
+
+Size formatting examples:
+- Auto (default): Chooses nearest unit (e.g., "1.44MB", "256KB")
+- Fixed unit: Set APPRISE_SIZE_UNIT to B, KB, MB, GB, or TB
 
 ## Security Features
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ services:
         volumes:
             - ./local_uploads:/app/uploads
         environment:
-            - DUMBDROP_PIN=123456
-            - APPRISE_URL=          # i.e. tgram://bottoken/ChatID
-            - APPRISE_MESSAGE=      # dont add quotes here
+            DUMBDROP_TITLE: DumbDrop fo shizzle
+            MAX_FILE_SIZE: 1024
+            DUMBDROP_PIN: 123456
+            # APPRISE_URL: ntfys://
+            APPRISE_MESSAGE: New file uploaded - {filename} ({size}), Storage used {storage} 
+            APPRISE_SIZE_UNIT: auto
         image: abite3/dumbdrop:latest
+        # build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         volumes:
             - ./local_uploads:/app/uploads
         environment:
-            DUMBDROP_TITLE: DumbDrop fo shizzle
+            DUMBDROP_TITLE: DumbDrop
             MAX_FILE_SIZE: 1024
             DUMBDROP_PIN: 123456
             # APPRISE_URL: ntfys://


### PR DESCRIPTION
# Enhanced Notification System with Storage Tracking

Related to:
https://github.com/DumbWareio/DumbDrop/issues/14
https://github.com/DumbWareio/DumbDrop/issues/15

Enhances the existing notification system with storage tracking and standardized message formats, making notifications more informative and configurable.

## Changes
- Added {size} template to display file size of uploaded file in notifications
- Added total storage tracking to notifications via {storage} template
- Added automatic file size formatting (B, KB, MB, GB, TB)
- Added APPRISE_SIZE_UNIT environment variable for size formatting control
- Standardized notification message formats
- Updated environment variable handling in docker-compose.yml
- Enhanced startup logging with storage information

## Environment Variables Added/Modified:
- `APPRISE_MESSAGE`: Now includes storage template (default: "New file uploaded {filename} ({size}), Storage used {storage}")
- `APPRISE_SIZE_UNIT`: Controls size unit display (auto, B, KB, MB, GB, TB)

## Technical Details
- Automatic size unit selection based on file size
- Configurable fixed size units via APPRISE_SIZE_UNIT
- Asynchronous storage size calculation
- Clean environment variable handling without quotes
- Enhanced logging of notification configuration
- Storage tracking across all uploaded files

## Message Templates
Now supports three placeholders:
- `{filename}`: Name of uploaded file
- `{size}`: Size of uploaded file
- `{storage}`: Total size of all files in upload directory

## Testing
- Tested with various file sizes for correct unit display
- Verified storage calculation accuracy
- Confirmed size unit configuration works
- Tested notification format with all placeholders
- Verified startup logging shows correct configuration
- Tested with and without APPRISE_SIZE_UNIT setting

## Example Usage
```yaml
environment:
    APPRISE_URL: ntfys://ntfy.example.com/dumbdumbdumb
    APPRISE_MESSAGE: New file uploaded {filename} ({size}), Storage used {storage}
    APPRISE_SIZE_UNIT: auto
```

Example notification: "New file uploaded example.pdf (2.54MB), Storage used 1.37GB"