### PR TITLE
feat: Duplicate file/folder handling 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,10 +216,16 @@
                             name: folderName,
                             isFolder: true,
                             totalSize: 0,
-                            files: []
+                            files: [],
+                            // Use the first file's batch ID or generate a new one
+                            batchId: file.batchId
                         });
                     }
                     const group = groups.get(folderName);
+                    // If group doesn't have a batch ID yet, use the file's batch ID
+                    if (!group.batchId) {
+                        group.batchId = file.batchId;
+                    }
                     group.files.push(file);
                     group.totalSize += file.size;
                 } else {
@@ -228,7 +234,8 @@
                         name: file.name,
                         isFolder: false,
                         totalSize: file.size,
-                        files: [file]
+                        files: [file],
+                        batchId: file.batchId
                     });
                 }
             });
@@ -245,7 +252,7 @@
                 if (entry.isFile) {
                     const file = await new Promise((resolve) => entry.file(resolve));
                     file.relativePath = path;
-                    file.batchId = batchId;
+                    file.batchId = batchId; // Use the same batch ID for all files in this drop
                     fileEntries.push(file);
                 } else if (entry.isDirectory) {
                     const reader = entry.createReader();
@@ -304,20 +311,29 @@
         function handleDrop(e) {
             const items = e.dataTransfer.items;
             if (items && items[0].webkitGetAsEntry) {
+                // Handle folder/file drop using DataTransferItemList
                 getAllFileEntries(items).then(newFiles => {
                     files = newFiles;
                     updateFileList();
                 });
             } else {
+                // Handle single file drop
+                const batchId = generateBatchId();
                 files = [...e.dataTransfer.files];
+                files.forEach(file => {
+                    file.relativePath = ''; // No relative path for dropped files
+                    file.batchId = batchId;
+                });
                 updateFileList();
             }
         }
 
         function handleFiles(e) {
+            const batchId = generateBatchId();
             files = [...e.target.files];
             files.forEach(file => {
                 file.relativePath = ''; // No relative path for individual files
+                file.batchId = batchId;
             });
             updateFileList();
         }
@@ -367,13 +383,15 @@
             document.getElementById('uploadProgress').innerHTML = '';
             
             const groupedItems = groupFilesByFolder(files);
-            const batchId = generateBatchId(); // Generate a single batch ID for all files
             
             const results = await Promise.all(
                 groupedItems.map(async item => {
                     let success = true;
+                    // Use the group's batch ID for all files in the group
+                    const groupBatchId = item.batchId || generateBatchId();
                     for (const file of item.files) {
-                        const uploader = new FileUploader(file, batchId);
+                        // Always use the group's batch ID
+                        const uploader = new FileUploader(file, groupBatchId);
                         if (!await uploader.start()) {
                             success = false;
                         }

--- a/public/index.html
+++ b/public/index.html
@@ -61,9 +61,15 @@
         const MAX_RETRIES = 3;
         const RETRY_DELAY = 1000;
 
+        // Utility function to generate a unique batch ID
+        function generateBatchId() {
+            return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        }
+
         class FileUploader {
-            constructor(file) {
+            constructor(file, batchId) {
                 this.file = file;
+                this.batchId = batchId;
                 this.uploadId = null;
                 this.position = 0;
                 this.progressElement = null;
@@ -90,7 +96,7 @@
                     method: 'POST',
                     headers: { 
                         'Content-Type': 'application/json',
-                        'X-Batch-ID': this.file.batchId || Date.now().toString()
+                        'X-Batch-ID': this.batchId
                     },
                     body: JSON.stringify({
                         filename: uploadPath,
@@ -233,7 +239,7 @@
         // Helper function to process directory entries
         async function getAllFileEntries(dataTransferItems) {
             let fileEntries = [];
-            const batchId = Date.now().toString();
+            const batchId = generateBatchId();
             
             async function traverseEntry(entry, path = '') {
                 if (entry.isFile) {
@@ -317,7 +323,7 @@
         }
 
         function handleFolders(e) {
-            const batchId = Date.now().toString();
+            const batchId = generateBatchId();
             files = [...e.target.files];
             files.forEach(file => {
                 const pathParts = file.webkitRelativePath.split('/');
@@ -361,11 +367,13 @@
             document.getElementById('uploadProgress').innerHTML = '';
             
             const groupedItems = groupFilesByFolder(files);
+            const batchId = generateBatchId(); // Generate a single batch ID for all files
+            
             const results = await Promise.all(
                 groupedItems.map(async item => {
                     let success = true;
                     for (const file of item.files) {
-                        const uploader = new FileUploader(file);
+                        const uploader = new FileUploader(file, batchId);
                         if (!await uploader.start()) {
                             success = false;
                         }

--- a/public/index.html
+++ b/public/index.html
@@ -88,7 +88,10 @@
 
                 const response = await fetch('/upload/init', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 
+                        'Content-Type': 'application/json',
+                        'X-Batch-ID': this.file.batchId || Date.now().toString()
+                    },
                     body: JSON.stringify({
                         filename: uploadPath,
                         fileSize: this.file.size
@@ -230,11 +233,13 @@
         // Helper function to process directory entries
         async function getAllFileEntries(dataTransferItems) {
             let fileEntries = [];
+            const batchId = Date.now().toString();
             
             async function traverseEntry(entry, path = '') {
                 if (entry.isFile) {
                     const file = await new Promise((resolve) => entry.file(resolve));
                     file.relativePath = path;
+                    file.batchId = batchId;
                     fileEntries.push(file);
                 } else if (entry.isDirectory) {
                     const reader = entry.createReader();
@@ -312,11 +317,13 @@
         }
 
         function handleFolders(e) {
+            const batchId = Date.now().toString();
             files = [...e.target.files];
             files.forEach(file => {
                 const pathParts = file.webkitRelativePath.split('/');
                 pathParts.pop(); // Remove filename
                 file.relativePath = pathParts.length > 0 ? pathParts.join('/') + '/' : '';
+                file.batchId = batchId;
             });
             updateFileList();
         }

--- a/server.js
+++ b/server.js
@@ -315,6 +315,9 @@ app.post('/upload/init', async (req, res) => {
         return res.status(400).json({ error: 'Invalid batch ID format' });
     }
 
+    // Always update batch activity timestamp for any upload
+    batchActivity.set(batchId, Date.now());
+
     const safeFilename = path.normalize(filename).replace(/^(\.\.(\/|\\|$))+/, '');
     
     // Check file size limit
@@ -360,9 +363,6 @@ app.post('/upload/init', async (req, res) => {
                 }
                 
                 folderMappings.set(`${originalFolderName}-${batchId}`, newFolderName);
-                
-                // Update batch activity timestamp instead of setting a timeout
-                batchActivity.set(batchId, Date.now());
             }
 
             // Replace the original folder path with the mapped one and keep original file name

--- a/server.js
+++ b/server.js
@@ -251,10 +251,22 @@ function getUniqueFolderPath(folderPath) {
     return newPath;
 }
 
+// Validate batch ID format
+function isValidBatchId(batchId) {
+    // Batch ID should be in format: timestamp-randomstring
+    return /^\d+-[a-z0-9]{9}$/.test(batchId);
+}
+
 // Routes
 app.post('/upload/init', async (req, res) => {
     const { filename, fileSize } = req.body;
-    const batchId = req.headers['x-batch-id'] || Date.now().toString();
+    const batchId = req.headers['x-batch-id'];
+
+    // Validate batch ID
+    if (!batchId || !isValidBatchId(batchId)) {
+        log.error('Invalid or missing batch ID');
+        return res.status(400).json({ error: 'Invalid or missing batch ID' });
+    }
 
     const safeFilename = path.normalize(filename).replace(/^(\.\.(\/|\\|$))+/, '');
     
@@ -268,7 +280,7 @@ app.post('/upload/init', async (req, res) => {
         });
     }
 
-    const uploadId = Date.now().toString();
+    const uploadId = crypto.randomBytes(16).toString('hex');
     let filePath = path.join(uploadDir, safeFilename);
     
     try {

--- a/server.js
+++ b/server.js
@@ -303,12 +303,16 @@ function isValidBatchId(batchId) {
 // Routes
 app.post('/upload/init', async (req, res) => {
     const { filename, fileSize } = req.body;
-    const batchId = req.headers['x-batch-id'];
+    let batchId = req.headers['x-batch-id'];
 
-    // Validate batch ID
-    if (!batchId || !isValidBatchId(batchId)) {
-        log.error('Invalid or missing batch ID');
-        return res.status(400).json({ error: 'Invalid or missing batch ID' });
+    // For single file uploads without a batch ID, generate one
+    if (!batchId) {
+        const timestamp = Date.now();
+        const randomStr = crypto.randomBytes(4).toString('hex').substring(0, 9);
+        batchId = `${timestamp}-${randomStr}`;
+    } else if (!isValidBatchId(batchId)) {
+        log.error('Invalid batch ID format');
+        return res.status(400).json({ error: 'Invalid batch ID format' });
     }
 
     const safeFilename = path.normalize(filename).replace(/^(\.\.(\/|\\|$))+/, '');


### PR DESCRIPTION
# Better File and Folder Duplication Handling

## Overview
This PR implements a more intuitive and consistent approach to handling duplicate files and folders.

## Key Changes

### Folder Handling
- When uploading a folder that already exists in the upload directory:
  - Creates a new folder with sequential numbering (e.g., "folder (1)", "folder (2)")
  - Preserves the original file names within the new folder
  - Example:
    ```
    uploads/
      folder/         # Original folder
        icon.png
        README.md
      folder (1)/     # Second upload
        file.txt    
        README.md         
    ```

### Single File Handling
- When uploading individual files that already exist:
  - Adds sequential numbers to duplicate files
  - Example: `file.txt` → `file (1).txt` → `file (2).txt`

### Technical Implementation
- Added batch ID system to track files from the same folder upload
- Implemented atomic file and folder creation to prevent race conditions
- Added cleanup mechanism for batch mappings after 5 minutes of inactivity
- Unified handling between drag-and-drop and folder browser uploads

## Testing
The following scenarios have been tested:
1. Single file upload with duplicates
2. Folder upload via drag-and-drop with duplicates
3. Folder upload via folder browser with duplicates
4. Mixed file and folder uploads
5. Concurrent uploads of the same folder

## Why you ask?! 
Because I was dumping amazon receipts into my instance to send to paperless-ngx and all the dumb receipts downloaded had the same file name and they kept overwriting eachother before my consume would consume.