### PR TITLE
Update pin input type to password to mask pin

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -81,7 +81,7 @@
             
             for (let i = 0; i < length; i++) {
                 const input = document.createElement('input');
-                input.type = 'text';
+                input.type = 'password';
                 input.className = 'pin-digit';
                 input.maxLength = 1;
                 input.pattern = '[0-9]';


### PR DESCRIPTION
Minor update to change the input type of the pin to 'password' so that it masks the pin just like the other dumbwareio products.
- noticed dumbdrop was the only one showing the pin in plaintext, so not sure if it was intentional but just thought i'd make this pr in case!
- if not needed i can close this pr

Thanks! 