### PR TITLE
Fixed notifications config mapping and filename sanitation/use of spawn for cve/rce

### DIFF
--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -20,6 +20,9 @@ services:
       - MAX_FILE_SIZE=1024
       - AUTO_UPLOAD=false
       - DUMBDROP_TITLE=DumbDrop-Dev
+      # - APPRISE_URL=ntfy://dumbdrop-test
+      # - APPRISE_MESSAGE=[DEV] New file uploaded - {filename} ({size}), Storage used {storage}
+      # - APPRISE_SIZE_UNIT=auto
     command: npm run dev
     restart: unless-stopped
     # Enable container debugging if needed

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <link rel="manifest" href="/manifest.json">
+    <link rel="icon" type="image/svg+xml" href="assets/icon.svg">
 </head>
 <body>
     <div class="container">

--- a/public/login.html
+++ b/public/login.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{SITE_TITLE}} - Login</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/svg+xml" href="assets/icon.svg">
     <style>
         .login-container {
             display: flex;

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -160,10 +160,16 @@ async function getUniqueFolderPath(folderPath) {
   return finalPath;
 }
 
+function sanitizeFilename(fileName) {
+  const sanitized = fileName.replace(/[<>:"/\\|?*]+/g, '').replace(/["`$|;&<>]/g, '');
+  return sanitized;
+}
+
 module.exports = {
   formatFileSize,
   calculateDirectorySize,
   ensureDirectoryExists,
   getUniqueFilePath,
-  getUniqueFolderPath
+  getUniqueFolderPath,
+  sanitizeFilename
 }; 


### PR DESCRIPTION
@abiteman hello, it's me 👋🏻

Bug Fix: notifications not triggering
CVE Fix: https://github.com/DumbWareio/DumbDrop/security/advisories/GHSA-rx8m-jqm7-vcgp

#### Changes:
- (Bug Fix): Fixed config properties that were not properly mapped so that notifications are actually sent now
- (Security): Use of spawn over exec to pass arguments directly to apprise (instead of using a direct shell command) - i believe this should address the CVE
<details>
<summary>Ensure filename sanitization before and during notification</summary>

#### BEFORE:
![before-rce-preview](https://github.com/user-attachments/assets/8bd6b001-fc45-480a-9399-6c2399b77daf)
- Filename still contains metacharacters when saved to server 
- Thankfully the execution doesn't actually run but thought it would be good to introduce additional filename sanitization before adding to server

#### AFTER:
![after-rce-preview](https://github.com/user-attachments/assets/324bb5f7-cadd-474d-a757-5d93c113b16f)
- Sanitizes the filename from metacharacters/potential shell commands when saving to server and passing the filename to the notification
- Notifications now work 📬
</details>

#### Other Changes:
<details>
<summary>Add svg to login / index for favicon (expand)</summary>

![favicon](https://github.com/user-attachments/assets/6ba43de9-53cf-43b3-a504-b33c5e223197)
- no more console error
</details>

- added apprise env vars (commented out) to docker-compose.dev.yml for testing purposes
- removed await on sendNotification calls. thought it wasn't necessary to pause execution here but lmk your thoughts and i can change that