### PR TITLE
feat: Enhance folder upload handling and filename sanitation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -516,6 +516,15 @@
             // Reset the input to allow selecting the same folder again
             const input = e.target;
             files = [...input.files];
+            // Check for webkitRelativePath support
+            const missingRelPath = files.some(f => !('webkitRelativePath' in f) || !f.webkitRelativePath);
+            if (missingRelPath) {
+                alert('Your browser does not support folder uploads with structure. Please use a modern browser like Chrome or Edge.');
+                files = [];
+                updateFileList();
+                input.value = '';
+                return;
+            }
             console.log('Folder selection files:', files.map(f => ({
                 name: f.name,
                 path: f.webkitRelativePath,

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -165,11 +165,20 @@ function sanitizeFilename(fileName) {
   return sanitized;
 }
 
+function sanitizePathPreserveDirs(filePath) {
+  // Split on forward slashes, sanitize each part, and rejoin
+  return filePath
+    .split('/')
+    .map(part => sanitizeFilename(part))
+    .join('/');
+}
+
 module.exports = {
   formatFileSize,
   calculateDirectorySize,
   ensureDirectoryExists,
   getUniqueFilePath,
   getUniqueFolderPath,
-  sanitizeFilename
+  sanitizeFilename,
+  sanitizePathPreserveDirs
 }; 


### PR DESCRIPTION
- Added support for checking webkitRelativePath in folder uploads, alerting users if their browser does not support this feature.
- Introduced sanitizePathPreserveDirs function to sanitize filenames while preserving directory structure.
- Updated upload route to utilize the new sanitation function and ensure consistent folder naming during uploads.

Fixes #45